### PR TITLE
Fix navbar overlap issue by adding padding-top to main content

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,7 @@
 
 .main-content {
   flex: 1;
+  padding-top: 80px; /* Add padding to prevent navbar overlap */
 }
 
 /* Global Reset and Base Styles */


### PR DESCRIPTION
Fixed Issue #36 

## Description
Fixed the navbar overlap issue where page content was getting hidden behind the fixed navbar, affecting readability and user experience.

## Changes Made
- Added `padding-top: 80px` to `.main-content` in `App.css` to create space for the fixed navbar

## Testing
- Verified that content is no longer hidden behind the navbar
- Checked responsiveness across different screen sizes

Fixes #[issue-number] (if there's a related issue)

<img width="1363" height="655" alt="image" src="https://github.com/user-attachments/assets/512340ac-ca3a-4b6b-b415-53f745e4a56a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the navbar from overlapping page content by adding appropriate top spacing to the main content area, improving readability and accessibility across viewports.
  * Content now consistently starts below the header on initial load and during navigation.

* **Style**
  * Tweaked vertical spacing for a more consistent layout flow, with no impact to features or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->