### PR TITLE
Dark Mode Fixes(#64)

### DIFF
--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,7 +1,12 @@
 .footer {
-  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-surface-muted) 0%,
+    var(--color-bg-muted) 100%
+  );
   color: var(--color-text);
   margin-top: auto;
+  border-top: 1px solid var(--color-border);
 }
 
 .footer-container {

--- a/src/pages/CommunityPage.css
+++ b/src/pages/CommunityPage.css
@@ -4,14 +4,14 @@ body {
   height: 100%;
 }
 
-.community-page{
+.community-page {
   min-height: 100vh;
 }
 
 .community-container {
   display: flex;
   flex-direction: column;
-  align-items: center; 
+  align-items: center;
   padding: 0;
   max-width: 900px;
   margin: 0 auto;
@@ -22,7 +22,7 @@ body {
 .community-title {
   font-size: 3rem;
   font-weight: 800;
-  color: #1e40af;
+  color: var(--color-primary);
   margin-bottom: 1rem;
 }
 
@@ -30,44 +30,52 @@ body {
 .community-subtitle {
   font-size: 1.25rem;
   line-height: 1.6;
-  color: #374151;
+  color: var(--color-text-muted);
   max-width: 650px;
 }
 
 /* Primary Button */
 .button {
-  background-color: #2563eb;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-primary-strong)
+  );
   color: white;
   padding: 0.85rem 2rem;
   border-radius: 0.5rem;
   text-decoration: none;
   font-weight: bold;
   box-shadow: 0 4px 10px rgba(37, 99, 235, 0.3);
-  transition: transform 0.2s ease, background-color 0.2s ease;
+  transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .button:hover {
-  background-color: #1d4ed8;
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-strong),
+    var(--color-primary)
+  );
   transform: translateY(-2px);
 }
 
 /* About Section */
 .community-about {
   max-width: 750px;
-  background: white;
+  background: var(--color-surface);
   padding: 2rem;
   border-radius: 0.75rem;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 20px var(--shadow-color);
 }
 
 .community-about h3 {
   font-size: 1.8rem;
   font-weight: bold;
-  color: #1f2937;
+  color: var(--color-text);
 }
 
 .community-about p {
-  color: #4b5563;
+  color: var(--color-text-muted);
   line-height: 1.6;
 }
 
@@ -76,8 +84,8 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding-left: 0; 
-  list-style: none; 
+  padding-left: 0;
+  list-style: none;
 }
 
 .contribution li {
@@ -88,7 +96,7 @@ body {
 
 .arrow-down {
   scale: 95%;
-  color: #646cff;
+  color: var(--color-primary);
 }
 
 .step {
@@ -99,15 +107,16 @@ body {
 }
 
 .step-box {
-  background: #dee1e4;
-  padding: 0.5rem 1rem; 
+  background: var(--color-bg-muted);
+  padding: 0.5rem 1rem;
   border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 2px 6px var(--shadow-color);
   font-weight: 500;
   width: 100%;
   max-width: 300px;
   text-align: center;
-  box-sizing: border-box; 
+  box-sizing: border-box;
+  color: var(--color-text);
 }
 
 .step-box h3,

--- a/src/pages/Contributors.css
+++ b/src/pages/Contributors.css
@@ -10,7 +10,11 @@
 
 /* Header Section */
 .contributors-header {
-  background: linear-gradient(135deg, #f9fafb 0%, #eef2ff 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-bg-muted) 0%,
+    var(--color-surface-muted) 100%
+  );
   padding: 3rem 0;
   text-align: center;
 }
@@ -18,13 +22,13 @@
 .contributors-title {
   font-size: 3rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-text);
   margin-bottom: 1rem;
 }
 
 .contributors-description {
   font-size: 1.25rem;
-  color: #6b7280;
+  color: var(--color-text-muted);
   max-width: 700px;
   margin: 0 auto;
   line-height: 1.6;
@@ -32,7 +36,7 @@
 
 /* Stats Section */
 .contributors-stats {
-  background: white;
+  background: var(--color-surface);
   padding: 3rem 0;
 }
 
@@ -45,7 +49,7 @@
 .stat-card {
   text-align: center;
   padding: 2rem 1rem;
-  background: #f9fafb;
+  background: var(--color-bg-muted);
   border-radius: 1rem;
   transition: transform 0.3s ease;
 }
@@ -62,26 +66,26 @@
 .stat-value {
   font-size: 2.5rem;
   font-weight: 800;
-  color: #1f2937;
+  color: var(--color-text);
   margin-bottom: 0.5rem;
 }
 
 .stat-label {
   font-size: 1rem;
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-weight: 500;
 }
 
 /* Featured Contributors */
 .featured-contributors {
-  background: #f9fafb;
+  background: var(--color-bg-muted);
   padding: 3rem 0;
 }
 
 .section-title {
   font-size: 2rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-text);
   margin-bottom: 2rem;
   text-align: center;
 }
@@ -93,11 +97,11 @@
 }
 
 .featured-card {
-  background: white;
+  background: var(--color-surface);
   padding: 2rem;
   border-radius: 1rem;
   text-align: center;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 20px var(--shadow-color);
   transition: transform 0.3s ease;
   position: relative;
 }
@@ -130,31 +134,35 @@
 .featured-name {
   font-size: 1.25rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-text);
   margin-bottom: 0.25rem;
 }
 
 .featured-role {
-  color: #3b82f6;
+  color: var(--color-primary);
   font-weight: 600;
   margin-bottom: 0.5rem;
 }
 
 .featured-contributions {
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-size: 0.9rem;
   margin-bottom: 1rem;
 }
 
 .featured-bio {
-  color: #4b5563;
+  color: var(--color-text-muted);
   line-height: 1.5;
   margin-bottom: 1.5rem;
   font-size: 0.9rem;
 }
 
 .featured-link {
-  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-primary-strong)
+  );
   color: white;
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
@@ -165,15 +173,19 @@
 }
 
 .featured-link:hover {
-  background: linear-gradient(135deg, #1d4ed8, #1e40af);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-strong),
+    var(--color-primary)
+  );
   transform: translateY(-2px);
 }
 
 /* Filters Section */
 .contributors-filters {
-  background: white;
+  background: var(--color-surface);
   padding: 2rem 0;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--color-border);
   position: sticky;
   top: 80px;
   z-index: 100;
@@ -203,15 +215,17 @@
 .search-input {
   width: 100%;
   padding: 0.75rem 1rem 0.75rem 3rem;
-  border: 2px solid #e5e7eb;
+  border: 2px solid var(--color-border);
   border-radius: 0.5rem;
   font-size: 1rem;
+  background: var(--color-surface);
+  color: var(--color-text);
   transition: border-color 0.3s ease;
 }
 
 .search-input:focus {
   outline: none;
-  border-color: #3b82f6;
+  border-color: var(--color-primary);
 }
 
 .search-icon {
@@ -219,7 +233,7 @@
   left: 1rem;
   top: 50%;
   transform: translateY(-50%);
-  color: #6b7280;
+  color: var(--color-text-muted);
 }
 
 .level-filters {
@@ -229,9 +243,9 @@
 }
 
 .filter-btn {
-  background: #f9fafb;
-  border: 2px solid #e5e7eb;
-  color: #6b7280;
+  background: var(--color-bg-muted);
+  border: 2px solid var(--color-border);
+  color: var(--color-text-muted);
   padding: 0.5rem 1rem;
   border-radius: 0.5rem;
   font-weight: 500;
@@ -243,13 +257,13 @@
 }
 
 .filter-btn:hover {
-  background: #f3f4f6;
-  border-color: #d1d5db;
+  background: var(--color-surface-muted);
+  border-color: var(--color-border);
 }
 
 .filter-btn.active {
-  background: #3b82f6;
-  border-color: #3b82f6;
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   color: white;
 }
 
@@ -260,11 +274,11 @@
 /* Contributors Grid Section */
 .contributors-grid-section {
   padding: 3rem 0;
-  background: #f9fafb;
+  background: var(--color-bg-muted);
 }
 
 .results-count {
-  color: #6b7280;
+  color: var(--color-text-muted);
   margin-bottom: 2rem;
   font-weight: 500;
 }
@@ -276,16 +290,16 @@
 }
 
 .contributor-card {
-  background: white;
+  background: var(--color-surface);
   border-radius: 1rem;
   padding: 1.5rem;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 20px var(--shadow-color);
   transition: all 0.3s ease;
 }
 
 .contributor-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+  box-shadow: 0 8px 30px var(--shadow-color);
 }
 
 .contributor-header {
@@ -330,12 +344,12 @@
 .contributor-name {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-text);
   margin-bottom: 0.25rem;
 }
 
 .contributor-username {
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-size: 0.9rem;
   margin-bottom: 0.5rem;
 }
@@ -373,7 +387,7 @@
   justify-content: space-around;
   margin-bottom: 1rem;
   padding: 1rem;
-  background: #f9fafb;
+  background: var(--color-bg-muted);
   border-radius: 0.5rem;
 }
 
@@ -384,24 +398,24 @@
 .stat-value {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #1f2937;
+  color: var(--color-text);
 }
 
 .stat-label {
   font-size: 0.8rem;
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-weight: 500;
 }
 
 .contributor-role {
-  color: #3b82f6;
+  color: var(--color-primary);
   font-weight: 600;
   margin-bottom: 0.25rem;
   font-size: 0.9rem;
 }
 
 .contributor-location {
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-size: 0.9rem;
   margin-bottom: 1rem;
 }
@@ -424,8 +438,8 @@
 }
 
 .skill-tag.more {
-  background: #f3f4f6;
-  color: #6b7280;
+  background: var(--color-bg-muted);
+  color: var(--color-text-muted);
 }
 
 .contributor-actions {
@@ -450,25 +464,33 @@
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-primary-strong)
+  );
   color: white;
   box-shadow: 0 4px 15px rgba(59, 130, 246, 0.3);
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, #1d4ed8, #1e40af);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-strong),
+    var(--color-primary)
+  );
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
 }
 
 .btn-secondary {
-  background: white;
-  color: #3b82f6;
-  border: 2px solid #3b82f6;
+  background: var(--color-surface);
+  color: var(--color-primary);
+  border: 2px solid var(--color-primary);
 }
 
 .btn-secondary:hover {
-  background: #3b82f6;
+  background: var(--color-primary);
   color: white;
   transform: translateY(-2px);
 }
@@ -477,9 +499,9 @@
 .no-results {
   text-align: center;
   padding: 4rem 2rem;
-  background: white;
+  background: var(--color-surface);
   border-radius: 1rem;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  box-shadow: 0 4px 20px var(--shadow-color);
 }
 
 .no-results-icon {
@@ -489,18 +511,22 @@
 
 .no-results h3 {
   font-size: 1.5rem;
-  color: #1f2937;
+  color: var(--color-text);
   margin-bottom: 0.5rem;
 }
 
 .no-results p {
-  color: #6b7280;
+  color: var(--color-text-muted);
   margin-bottom: 2rem;
 }
 
 /* Join CTA */
 .join-cta {
-  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-strong) 0%,
+    var(--color-primary) 100%
+  );
   padding: 4rem 0;
   color: white;
 }
@@ -519,7 +545,7 @@
 
 .cta-content p {
   font-size: 1.25rem;
-  color: #d1d5db;
+  color: rgba(255, 255, 255, 0.85);
   margin-bottom: 2.5rem;
   line-height: 1.6;
 }

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -14,7 +14,11 @@
 
 /* Hero Section */
 .hero {
-  background: linear-gradient(135deg, var(--color-bg-muted) 0%, #eef2ff 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-bg-muted) 0%,
+    var(--color-surface-muted) 100%
+  );
   padding: 4rem 0;
   overflow: hidden;
 }
@@ -111,8 +115,13 @@
 }
 
 @keyframes float {
-  0%, 100% { transform: translateY(0px); }
-  50% { transform: translateY(-20px); }
+  0%,
+  100% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-20px);
+  }
 }
 
 /* Buttons */
@@ -129,13 +138,21 @@
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-primary-strong)
+  );
   color: white;
   box-shadow: 0 4px 15px rgba(59, 130, 246, 0.3);
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, var(--color-primary-strong), var(--color-primary));
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-strong),
+    var(--color-primary)
+  );
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
 }
@@ -154,12 +171,12 @@
 
 .btn-outline {
   background: transparent;
-  color: #3b82f6;
-  border: 2px solid #3b82f6;
+  color: var(--color-primary);
+  border: 2px solid var(--color-primary);
 }
 
 .btn-outline:hover {
-  background: #3b82f6;
+  background: var(--color-primary);
   color: white;
 }
 
@@ -195,7 +212,7 @@
 .stat-label {
   font-size: 1.1rem;
   color: var(--color-text-muted);
-font-weight: 500;
+  font-weight: 500;
 }
 
 /* Features Section */
@@ -280,7 +297,11 @@ font-weight: 500;
 /* CTA Section */
 .cta {
   padding: 4rem 0;
-  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-strong) 0%,
+    var(--color-primary) 100%
+  );
   color: white;
 }
 
@@ -294,11 +315,12 @@ font-weight: 500;
   font-size: 2.5rem;
   font-weight: 700;
   margin-bottom: 1rem;
+  color: white;
 }
 
 .cta-description {
   font-size: 1.25rem;
-  color: #d1d5db;
+  color: rgba(255, 255, 255, 0.9);
   margin-bottom: 2.5rem;
   line-height: 1.6;
 }

--- a/src/pages/Programs.css
+++ b/src/pages/Programs.css
@@ -10,7 +10,11 @@
 
 /* Header Section */
 .programs-header {
-  background: linear-gradient(135deg, var(--color-bg-muted) 0%, #eef2ff 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-bg-muted) 0%,
+    var(--color-surface-muted) 100%
+  );
   padding: 3rem 0;
   text-align: center;
 }
@@ -164,13 +168,21 @@
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--color-primary), var(--color-primary-strong));
+  background: linear-gradient(
+    135deg,
+    var(--color-primary),
+    var(--color-primary-strong)
+  );
   color: white;
   box-shadow: 0 4px 15px rgba(59, 130, 246, 0.3);
 }
 
 .btn-primary:hover {
-  background: linear-gradient(135deg, var(--color-primary-strong), var(--color-primary));
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-strong),
+    var(--color-primary)
+  );
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(59, 130, 246, 0.4);
 }
@@ -189,7 +201,11 @@
 
 /* CTA Section */
 .programs-cta {
-  background: linear-gradient(135deg, #1f2937 0%, #111827 100%);
+  background: linear-gradient(
+    135deg,
+    var(--color-primary-strong) 0%,
+    var(--color-primary) 100%
+  );
   padding: 4rem 0;
   color: white;
 }
@@ -208,7 +224,7 @@
 
 .cta-content p {
   font-size: 1.25rem;
-  color: #d1d5db;
+  color: rgba(255, 255, 255, 0.85);
   margin-bottom: 2.5rem;
   line-height: 1.6;
 }


### PR DESCRIPTION
### Dark Mode Fixes

- Replaced all hardcoded colors with CSS variables across 5+ pages
- Fixed text visibility issues (mentor stats, names, titles now use var(--color-text))
- Updated backgrounds, borders, and shadows to respond to theme toggle
- Added dark mode specific overrides for stat numbers (pure white, font-weight: 900)

<img width="1920" height="913" alt="Screenshot (136)" src="https://github.com/user-attachments/assets/08871d89-072b-404e-b5fa-e68006577cc1" />

<img width="1920" height="894" alt="Screenshot (137)" src="https://github.com/user-attachments/assets/16ebf500-2b32-4438-8883-8ba781ad84e9" />
