### PR TITLE
feat: Replace placeholder avatars with real GitHub avatars in Contributors page

### DIFF
--- a/src/utils/githubApi.js
+++ b/src/utils/githubApi.js
@@ -1,0 +1,69 @@
+// GitHub API utility functions
+const GITHUB_API_BASE = 'https://api.github.com';
+
+// Function to get GitHub user avatar
+export const getGitHubAvatar = (username) => {
+  return `https://github.com/${username}.png?size=150`;
+};
+
+// Function to get GitHub user info
+export const getGitHubUserInfo = async (username) => {
+  try {
+    const response = await fetch(`${GITHUB_API_BASE}/users/${username}`);
+    if (!response.ok) {
+      throw new Error(`GitHub API error: ${response.status}`);
+    }
+    const userData = await response.json();
+    return {
+      avatar: userData.avatar_url,
+      name: userData.name || userData.login,
+      bio: userData.bio,
+      location: userData.location,
+      publicRepos: userData.public_repos,
+      followers: userData.followers,
+      following: userData.following,
+      githubUrl: userData.html_url,
+      joinDate: userData.created_at
+    };
+  } catch (error) {
+    console.error(`Error fetching GitHub data for ${username}:`, error);
+    // Return fallback data
+    return {
+      avatar: getGitHubAvatar(username),
+      name: username,
+      bio: null,
+      location: null,
+      publicRepos: 0,
+      followers: 0,
+      following: 0,
+      githubUrl: `https://github.com/${username}`,
+      joinDate: null
+    };
+  }
+};
+
+// Function to get multiple GitHub users info
+export const getMultipleGitHubUsers = async (usernames) => {
+  const promises = usernames.map(username => getGitHubUserInfo(username));
+  return Promise.all(promises);
+};
+
+// Function to get repository contributors
+export const getRepositoryContributors = async (owner, repo) => {
+  try {
+    const response = await fetch(`${GITHUB_API_BASE}/repos/${owner}/${repo}/contributors`);
+    if (!response.ok) {
+      throw new Error(`GitHub API error: ${response.status}`);
+    }
+    const contributors = await response.json();
+    return contributors.map(contributor => ({
+      username: contributor.login,
+      avatar: contributor.avatar_url,
+      contributions: contributor.contributions,
+      githubUrl: contributor.html_url
+    }));
+  } catch (error) {
+    console.error(`Error fetching contributors for ${owner}/${repo}:`, error);
+    return [];
+  }
+};


### PR DESCRIPTION
## **Issue Description:**

### **Issue Title:**
**feat: Replace placeholder avatars with real GitHub avatars in Contributors page**

### **Issue Description:**
The Contributors page currently uses placeholder avatars (`https://via.placeholder.com/150x150/...`) instead of real GitHub profile pictures, making the page look unprofessional and not showcasing actual community members.

**Current behavior:**
- Contributors page displays generic placeholder images
- No integration with GitHub API for real user data
- Static mock data without dynamic fetching
- No loading states during data retrieval

**Expected behavior:**
- Real GitHub profile pictures should be displayed
- Dynamic data fetching from GitHub API
- Loading states during data retrieval
- Graceful fallback if API fails
- Enhanced contributor information from GitHub

**Changes made:**
- ✅ Created GitHub API utility functions (`src/utils/githubApi.js`)
- ✅ Updated Contributors page to fetch real GitHub data
- ✅ Added loading spinner during data fetch
- ✅ Implemented error handling with fallback to GitHub avatars
- ✅ Enhanced contributor data with GitHub information (bio, location, repos, followers)



**Files modified:**
- `src/utils/githubApi.js` - New GitHub API utility functions
- `src/pages/Contributors.jsx` - Updated to use real GitHub data

#99 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contributors page now displays real-time GitHub profile data including bios, locations, follower counts, and public repository information.
  * Loading indicator displays while fetching contributor information.
  * Graceful fallback ensures contributors display if data retrieval is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


https://github.com/user-attachments/assets/88e144ee-40be-4d95-a294-7e2462a9f291

