### PR TITLE
Fix: module visibility issue in dark mode

### DIFF
--- a/src/pages/LearningTrack.jsx
+++ b/src/pages/LearningTrack.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { BookOpen, Clock, Users, CheckCircle, PlayCircle, Target, Award, ArrowRight } from 'lucide-react';
 import learningTracks from '../data/learningTracks.json';
@@ -65,16 +65,6 @@ const LearningTrack = () => {
     setSelectedTrack(trackId);
   };
 
-  const completeModule = (moduleId) => {
-    if (!userProgress.completedModules.includes(moduleId)) {
-      setUserProgress(prev => ({
-        ...prev,
-        completedModules: [...prev.completedModules, moduleId],
-        progress: calculateProgress(prev.currentTrack)
-      }));
-    }
-  };
-
   const navigateToModule = (trackId, moduleId) => {
     navigate(`/learning/${trackId}/${moduleId}`);
   };
@@ -126,7 +116,7 @@ const LearningTrack = () => {
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
             {learningTracks.map((track) => (
-              <div key={track.id} className="bg-white rounded-2xl shadow-xl overflow-hidden hover:shadow-2xl transition-all duration-300 hover:-translate-y-2 flex flex-col h-full">
+              <div key={track.id} className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl overflow-hidden hover:shadow-2xl transition-all duration-300 hover:-translate-y-2 flex flex-col h-full">
                 {/* Track Header */}
                 <div className={`bg-gradient-to-r ${getTrackColor(track.color)} p-8 text-white`}>
                   <div className="flex items-center justify-between mb-4">


### PR DESCRIPTION
Problem:
In the Learning page (/learning), when Dark Mode was enabled, the "Modules (4)" heading text on all track cards (Beginner, Intermediate, Advanced) was blending into the background, making it difficult to read or nearly invisible. 

Root Cause:
The card containers didn't have an explicit background color set for dark mode, causing the white text to lack proper contrast against the dark background.

Solution:
Updated the learning track card containers to include explicit dark mode background styling:
Changed bg-white to bg-white dark:bg-gray-800 for the main card container
This ensures proper contrast between the white text and dark background in dark mode
Maintained existing light mode styling (white background)

Fixes #135

<img width="2880" height="1560" alt="image" src="https://github.com/user-attachments/assets/ecf17b44-93ad-4700-bafc-4d0f20453a03" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode styling for learning track cards to improve visual consistency across light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->